### PR TITLE
README typo fix, and update of vendor publish doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Metrogistics\AzureSocialite\ServiceProvider::class,
 Publish the config and override any defaults:
 
 ```
-php artisan vendor publish
+php artisan vendor:publish
 ```
 
 Add the necessary env vars:

--- a/src/config/azure-oath.php
+++ b/src/config/azure-oath.php
@@ -17,7 +17,7 @@ return [
     'credentials' => [
         'client_id' => env('AZURE_AD_CLIENT_ID', ''),
         'client_secret' => env('AZURE_AD_CLIENT_SECRET', ''),
-        'redirect' => Request::root().'/login/microsoft/callback'
+        'redirect' => '/login/microsoft/callback'
     ],
 
     // The route to redirect the user to upon login.


### PR DESCRIPTION
This PR includes 2 very simple changes:
1. Fixing a typo in the README ("php artisan vendor publish" should be "php artisan vendor:publish")
2. In the published file, the redirect does not need "Request::root()."