### PR TITLE
Fix exception usage and ability to add params to the code request link

### DIFF
--- a/src/AzureOauthProvider.php
+++ b/src/AzureOauthProvider.php
@@ -3,6 +3,7 @@
 namespace Metrogistics\AzureSocialite;
 
 use Illuminate\Support\Arr;
+use Laravel\Socialite\Two\InvalidStateException;
 use Laravel\Socialite\Two\User;
 use Laravel\Socialite\Two\AbstractProvider;
 use Laravel\Socialite\Two\ProviderInterface;

--- a/src/AzureOauthProvider.php
+++ b/src/AzureOauthProvider.php
@@ -62,6 +62,11 @@ class AzureOauthProvider extends AbstractProvider implements ProviderInterface
                     ->setRefreshToken(Arr::get($response, 'refresh_token'));
     }
 
+    protected function getCodeFields($state = null)
+    {
+        return array_merge(config('azure-oath.code_fields', []), parent::getCodeFields($state));
+    }
+
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([

--- a/src/config/azure-oath.php
+++ b/src/config/azure-oath.php
@@ -20,6 +20,12 @@ return [
         'redirect' => Request::root().'/login/microsoft/callback'
     ],
 
+    // The fields that will be added to generated code request link
+    // You can't override the default ones here, like client_id, redirect_uri, state, etc.
+    'code_fields' => [
+        //'prompt' => 'login', // uncomment to force users fill their credentials in Azure
+    ],
+
     // The route to redirect the user to upon login.
     'redirect_on_login' => '/home',
 


### PR DESCRIPTION
Docs for Azure oath have listed additional parameters that you can pass to the link for request an authorization code, f.e.:
"prompt" - using to change which user interactions are required. you might force users to fill their creds or opposite login only when no interactions is needed...
"login_hint" - prefill for login
"domain_hint" - prefill for domain 
and some others.